### PR TITLE
feat: Match fields by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,50 @@
 # Redact-it
+
 A flexible and easy way to redact data from objects.
 
 ## Why?
+
 This project was designed from real-world scenarios composed of 2 main concerns:
+
 1. Preventing sensitive data to be written in logs;
 1. Investigating production requests by using meaningful log messages and contexts;
 
-The first one is by far the most important. If an attack or some failure 
+The first one is by far the most important. If an attack or some failure
 exposes logs, sensitive data might come within them. Surely, most systems are designed
 to never let it happen. But in case it does, have sensitive data redacted mitigates
-the negative impact. 
+the negative impact.
 
-To solve that, one way is to never print any data to logs. However, 
-context logging may save a lot of time on debugging or investigating a specific 
-situation in production. 
+To solve that, one way is to never print any data to logs. However,
+context logging may save a lot of time on debugging or investigating a specific
+situation in production.
 
 ## How?
-Since neither approaches are ideal for both parts, the owner of the data may 
-determine how much of the actual data can be printed out to logs. Depending on 
+
+Since neither approaches are ideal for both parts, the owner of the data may
+determine how much of the actual data can be printed out to logs. Depending on
 the type of data logged, partial printing can be used to be a middle point between
-the two concerns. This is where this tiny library comes in handy :) 
+the two concerns. This is where this tiny library comes in handy :)
 
 This library helps to build a replacer function flexible enough to declare
 which fields are going to be redacted and how.
 
 Then, the replacer function might be used with the logging tool of your choice.
-In the tests and following examples, we are using the 
-[`JSON.stringify()`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) 
+In the tests and following examples, we are using the
+[`JSON.stringify()`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 for its simplicity.
 
 ## Docs
-The most important concepts to read about are documented in 
+
+The most important concepts to read about are documented in
 [this file](https://github.com/alanpcs/redact-it/blob/master/typings/index.ts).
 
 ## Examples
+
 _We have some tests with more usage examples, check them out_
 _[here](https://github.com/alanpcs/redact-it/tree/master/test/unit)!_
 
-
 For the following examples, we are going to use this main object as reference:
+
 ```typescript
 const userInfoToBeLogged = {
   password: "123",
@@ -52,13 +58,14 @@ const userInfoToBeLogged = {
 ```
 
 ### Default usage
+
 If the idea is to redact the data entirely, you just need to to name the fields.
-The default `Mask` is the `percentage` with `100`% redacting with the fixed 
+The default `Mask` is the `percentage` with `100`% redacting with the fixed
 string `[redacted]`;
 
 ```typescript
 const redactItConfig: RedactItConfig = {
-    fields: ["password", "cvv"]
+  fields: ["password", "cvv"],
 };
 
 const replacerFunction: ReplacerFunction = redactIt(redactItConfig);
@@ -83,21 +90,25 @@ const parsedResult = JSON.parse(stringResult);
 
 ```typescript
 const redactItConfig: RedactItConfig = [
-    {
-        fields: ["password"], // which fields to redact
-        mask: {  // How to redact the fields
-            type: "undefine" // the undefine mask removes the fields
-        }
+  {
+    fields: ["password"], // which fields to redact
+    mask: {
+      // How to redact the fields
+      type: "undefine", // the undefine mask removes the fields
     },
-    {
-        fields: ["expirationDate", "number"], 
-        mask: {
-            type: "percentage", // Percentage masks redact data partially
-            redactWith: "•", // Redacted characters replaced by •
-            percentage: 75 // 75% of the value should be redacted
-        }
+  },
+  {
+    fields: [/token/i], // Will match the regex against all fields
+  },
+  {
+    fields: ["expirationDate", "number"],
+    mask: {
+      type: "percentage", // Percentage masks redact data partially
+      redactWith: "•", // Redacted characters replaced by •
+      percentage: 75, // 75% of the value should be redacted
     },
-    { fields: ["cvv"] } // if no mask is passed, fields values are redacted as [redacted]
+  },
+  { fields: ["cvv"] }, // if no mask is passed, fields values are redacted as [redacted]
 ];
 
 const replacerFunction: ReplacerFunction = redactIt(redactItConfig);
@@ -108,6 +119,7 @@ const parsedResult = JSON.parse(stringResult);
 /* parsedResult
 {
   name: 'foo',
+  TOKEN: 'redacted',
   card: {
     number: '••••••••••••4321',
     cvv: '[redacted]',
@@ -118,12 +130,15 @@ const parsedResult = JSON.parse(stringResult);
 ```
 
 ## Objectives
-This project aims to have a flexible yet powerful API to create a replacer 
+
+This project aims to have a flexible yet powerful API to create a replacer
 function to redact partial or entire object values.
 
 ### Roadmap
+
 - Support partial email redacting
 
 ## Contributing
-If you like this project and want to contribute with it, you can fork it and 
+
+If you like this project and want to contribute with it, you can fork it and
 create a pull request :)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For the following examples, we are going to use this main object as reference:
 const userInfoToBeLogged = {
   password: "123",
   name: "foo",
+  TOKEN: "my-secret-access-token",
   card: {
     number: "1234567887654321",
     cvv: "123",
@@ -119,7 +120,7 @@ const parsedResult = JSON.parse(stringResult);
 /* parsedResult
 {
   name: 'foo',
-  TOKEN: 'redacted',
+  TOKEN: '[redacted]',
   card: {
     number: '••••••••••••4321',
     cvv: '[redacted]',

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -68,6 +68,11 @@ export const redactIt: RedactIt = (
   });
 
   const getMaskForKey = (key: any): Mask | null => {
+    const mask = mappedFields.get(key);
+    if (mask) {
+      return mask;
+    }
+
     for (const [matcher, mask] of mappedFields.entries()) {
       if (matcher instanceof RegExp) {
         if (matcher.test(key)) {

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -55,7 +55,7 @@ export const redactIt: RedactIt = (
     mask: defaultMask,
   };
 
-  const mappedFields: any = {};
+  const mappedFields: Map<string | RegExp, Mask> = new Map();
 
   const optionsArray: RedacItConfig[] = Array.isArray(configs)
     ? configs
@@ -63,12 +63,25 @@ export const redactIt: RedactIt = (
 
   optionsArray.forEach((option: RedacItConfig) => {
     option.fields.forEach((field) => {
-      mappedFields[field] = option.mask ?? defaultMask;
+      mappedFields.set(field, option.mask ?? defaultMask);
     });
   });
 
-  const replacer = (key: string, value: string): any => {
-    const mask = mappedFields[key];
+  const getMaskForKey = (key: any): Mask | null => {
+    for (const [matcher, mask] of mappedFields.entries()) {
+      if (matcher instanceof RegExp) {
+        if (matcher.test(key)) {
+          return mask;
+        }
+      } else if (matcher === key) {
+        return mask;
+      }
+    }
+    return null;
+  };
+
+  const replacer = (key: any, value: any): any => {
+    const mask = getMaskForKey(key);
     if (mask) {
       if (mask.type === "undefine") {
         return undefined;

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -76,6 +76,27 @@ describe("Redact-it - Single configs argument", () => {
     expect(parsedResult.card.cvv).to.be.undefined;
   });
 
+  /**
+   * By using `map[key]` directly, there is a risk we try to access Object.prototype keys,
+   * which is unsafe and may cause issues
+   */
+  it("should not redact Object.prototype keys", async () => {
+    const myData = {
+      constructor: () => 1,
+      toString: () => 1,
+      valueOf: () => 1,
+      hasOwnProperty: () => 1,
+      isPrototypeOf: () => 1,
+      propertyIsEnumerable: () => 1,
+    };
+    const replacerFunction: ReplacerFunction = redactIt();
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+    const parsedResult = JSON.parse(stringResult);
+
+    expect(parsedResult).to.be.deep.eq({});
+  });
+
   it("should redact the first 12 digits of a 16 digits value when a 75% percentage mask is used", async () => {
     const myData = { ...defaultObject };
     const replacerFunction: ReplacerFunction = redactIt({

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -228,4 +228,40 @@ describe("Redact-it - Multiple configs argument", () => {
       cvv: "[redacted]",
     });
   });
+
+  it("should prefer perfect match over a regex", async () => {
+    const myData = {
+      AUTHORIZATION: "uppercase",
+      authorization: "lowercase",
+      Authorization: "capitalized",
+    };
+    const replacerFunction: ReplacerFunction = redactIt([
+      {
+        fields: ["Authorization"],
+        mask: {
+          type: "undefine",
+        },
+      },
+      {
+        fields: [/Authorization/i],
+        mask: {
+          type: "percentage",
+          percentage: 50,
+          redactWith: "•",
+        },
+      },
+      {
+        fields: ["AUTHORIZATION"],
+        mask: {
+          type: "undefine",
+        },
+      },
+    ]);
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+
+    expect(JSON.parse(stringResult)).to.deep.equal({
+      authorization: "•••••case",
+    });
+  });
 });

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -44,6 +44,25 @@ describe("Redact-it - Single configs argument", () => {
     });
   });
 
+  it("should redact based on regex field", async () => {
+    const myData = {
+      AUTHORIZATION: "uppercase",
+      authorization: "lowercase",
+      Authorization: "capitalized",
+    };
+    const replacerFunction: ReplacerFunction = redactIt({
+      fields: [/Authorization/i],
+    });
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+
+    expect(JSON.parse(stringResult)).to.deep.equal({
+      AUTHORIZATION: "[redacted]",
+      authorization: "[redacted]",
+      Authorization: "[redacted]",
+    });
+  });
+
   it("should remove the fields when the 'undefine' mask is used", async () => {
     const myData = { ...defaultObject };
     const replacerFunction: ReplacerFunction = redactIt({

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -19,14 +19,11 @@ export interface Mask {
  *  @param {Mask} mask - Which mask to apply
  */
 export interface RedacItConfig {
-  fields: string[];
+  fields: (string | RegExp)[];
   mask?: Mask;
 }
 
-export type ReplacerFunction = (
-  key: string,
-  value: string
-) => string | undefined;
+export type ReplacerFunction = (key: any, value: any) => any;
 
 /**
  *  A function that takes the argument and creates a replacer function


### PR DESCRIPTION
When dealing with a shared library, developers may use different casings or slightly different field names. Allowing regexes to be matched increases flexibililty.

Also, we found a bug where redacting an object with the key `constructor` would cause it to be redacted. This is caused by using `mappedFields[key]` directly and was solved by using a `Map` instead.