### PR TITLE
feat: 'replace' mask

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
       { "argsIgnorePattern": "^_" }
     ],
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/explicit-function-return-type": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ const userInfoToBeLogged = {
     cvv: "123",
     expirationDate: "2020-12-20",
   },
+  authorization: "Bearer token",
 };
 ```
 
 ### Default usage
 
 If the idea is to redact the data entirely, you just need to to name the fields.
-The default `Mask` is the `percentage` with `100`% redacting with the fixed
-string `[redacted]`;
+The default `Mask` is the `replace` with the fixed string `[redacted]`:
 
 ```typescript
 const redactItConfig: RedactItConfig = {
-  fields: ["password", "cvv"],
+  fields: ["password", "cvv", "TOKEN", "authorization"],
 };
 
 const replacerFunction: ReplacerFunction = redactIt(redactItConfig);
@@ -78,11 +78,13 @@ const parsedResult = JSON.parse(stringResult);
 {
   name: 'foo',
   password: '[redacted]',
+  TOKEN: '[redacted]'
   card: {
     number: '1234567887654321',
     cvv: '[redacted]',
     expirationDate: '2020-12-20',
-  }
+  },
+  authorization: "[redacted]"
 }
 */
 ```
@@ -109,6 +111,13 @@ const redactItConfig: RedactItConfig = [
       percentage: 75, // 75% of the value should be redacted
     },
   },
+  {
+    fields: ["authorization"],
+    mask: {
+      type: "replace", // Replaces the whole value with the `redactWith` string
+      redactWith: "[REDACTED FOR COMPLIANCE REASONS]",
+    },
+  },
   { fields: ["cvv"] }, // if no mask is passed, fields values are redacted as [redacted]
 ];
 
@@ -125,7 +134,8 @@ const parsedResult = JSON.parse(stringResult);
     number: '••••••••••••4321',
     cvv: '[redacted]',
     expirationDate: '••••••••20'
-  }
+  },
+  authorization: "[REDACTED FOR COMPLIANCE REASONS]"
 }
 */
 ```

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -6,6 +6,10 @@ const valueMasker = (value: any, mask: Mask): string => {
   const complementary = mask.complementary ?? false;
   const position = mask.position ?? "left";
 
+  if (mask.type === "replace") {
+    return redactor;
+  }
+
   const finalRedactor = (p1: string): string =>
     redactor.length > 1 ? redactor : p1.replace(/./g, redactor);
 
@@ -47,7 +51,8 @@ export const redactIt: RedactIt = (
   configs?: RedacItConfig | RedacItConfig[]
 ): ReplacerFunction => {
   const defaultMask: Mask = {
-    type: "percentage",
+    type: "replace",
+    redactWith: "[redacted]",
   };
 
   const defaultOptions: RedacItConfig = {

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -1,14 +1,19 @@
-import { Mask, RedactIt, RedacItConfig, ReplacerFunction } from "../typings";
+import {
+  Mask,
+  RedactIt,
+  RedacItConfig,
+  ReplacerFunction,
+  PercentageMask,
+} from "../typings";
 
-const valueMasker = (value: any, mask: Mask): string => {
+const percentageValueMasker = (
+  value: any,
+  mask: PercentageMask
+): string | undefined => {
   const redactor = mask.redactWith ?? "[redacted]";
   const percentage = mask.percentage ?? 100;
   const complementary = mask.complementary ?? false;
   const position = mask.position ?? "left";
-
-  if (mask.type === "replace") {
-    return redactor;
-  }
 
   const finalRedactor = (p1: string): string =>
     redactor.length > 1 ? redactor : p1.replace(/./g, redactor);
@@ -93,10 +98,13 @@ export const redactIt: RedactIt = (
   const replacer = (key: any, value: any): any => {
     const mask = getMaskForKey(key);
     if (mask) {
+      if (mask.type === "replace") {
+        return mask.redactWith;
+      }
       if (mask.type === "undefine") {
         return undefined;
       }
-      return valueMasker(value, mask);
+      return percentageValueMasker(value, mask);
     }
     return value;
   };

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -10,7 +10,7 @@ const percentageValueMasker = (
   value: any,
   mask: PercentageMask
 ): string | undefined => {
-  const redactor = mask.redactWith ?? "[redacted]";
+  const redactor = mask.redactWith ?? "•";
   const percentage = mask.percentage ?? 100;
   const complementary = mask.complementary ?? false;
   const position = mask.position ?? "left";

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -3,14 +3,16 @@ import { redactIt } from "../../src/redact-it";
 import { ReplacerFunction } from "../../typings";
 
 const defaultObject = {
-  password: "123",
+  password: "senha.muito.segura123",
   name: "foo",
   email: "foo123456789email@bar.com",
+  TOKEN: "my-secret-access-token",
   card: {
     number: "1234567887654321",
     cvv: "123",
     expirationDate: "2020-12-20",
   },
+  authorization: "Bearer token",
 };
 
 describe("Redact-it - Single configs argument", () => {
@@ -60,6 +62,24 @@ describe("Redact-it - Single configs argument", () => {
       AUTHORIZATION: "[redacted]",
       authorization: "[redacted]",
       Authorization: "[redacted]",
+    });
+  });
+
+  it("should use redactWith string if 'replace' mask is used", async () => {
+    const myData = { ...defaultObject };
+    const replacerFunction: ReplacerFunction = redactIt({
+      fields: ["password"],
+      mask: {
+        type: "replace",
+        redactWith: "[REDACTED]",
+      },
+    });
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+
+    expect(JSON.parse(stringResult)).to.deep.equal({
+      ...defaultObject,
+      password: "[REDACTED]",
     });
   });
 

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -165,7 +165,7 @@ describe("Redact-it - Single configs argument", () => {
     );
   });
 
-  it("should redact the beginning and ending digits when position center is used and complementary is tru", async () => {
+  it("should redact the beginning and ending digits when position center is used and complementary is true", async () => {
     const myData = { ...defaultObject };
     const replacerFunction: ReplacerFunction = redactIt({
       fields: ["email"],
@@ -182,6 +182,22 @@ describe("Redact-it - Single configs argument", () => {
 
     expect(JSON.parse(stringResult).email).to.be.eq(
       "******456789email@b******"
+    );
+  });
+
+  it("should default to 100% mask with • if percentage mask is used", async () => {
+    const myData = { ...defaultObject };
+    const replacerFunction: ReplacerFunction = redactIt({
+      fields: ["email"],
+      mask: {
+        type: "percentage",
+      },
+    });
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+
+    expect(JSON.parse(stringResult).email).to.be.eq(
+      "•••••••••••••••••••••••••"
     );
   });
 });

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -3,7 +3,7 @@ import { redactIt } from "../../src/redact-it";
 import { ReplacerFunction } from "../../typings";
 
 const defaultObject = {
-  password: "senha.muito.segura123",
+  password: "very.strong.password123",
   name: "foo",
   email: "foo123456789email@bar.com",
   TOKEN: "my-secret-access-token",
@@ -71,7 +71,7 @@ describe("Redact-it - Single configs argument", () => {
       fields: ["password"],
       mask: {
         type: "replace",
-        redactWith: "[REDACTED]",
+        redactWith: "(ommited value)",
       },
     });
 
@@ -79,7 +79,7 @@ describe("Redact-it - Single configs argument", () => {
 
     expect(JSON.parse(stringResult)).to.deep.equal({
       ...defaultObject,
-      password: "[REDACTED]",
+      password: "(ommited value)",
     });
   });
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -5,12 +5,21 @@
  *  @param {number} percentage - Percentage of the value to apply the mask on
  *  @param {boolean} complementary - Whether the complemetary part of the percentage should be masked
  */
-export interface Mask {
-  type: "percentage" | "undefine" | "replace";
+export type Mask = PercentageMask | UndefineMask | ReplaceMask;
+
+export interface PercentageMask {
+  type: "percentage";
   redactWith?: "*" | "•" | "[redacted]" | string;
   percentage?: number;
   complementary?: boolean;
   position?: "left" | "center" | "right";
+}
+export interface UndefineMask {
+  type: "undefine";
+}
+export interface ReplaceMask {
+  type: "replace";
+  redactWith: "[redacted]" | string;
 }
 
 /**

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -6,7 +6,7 @@
  *  @param {boolean} complementary - Whether the complemetary part of the percentage should be masked
  */
 export interface Mask {
-  type: "percentage" | "undefine";
+  type: "percentage" | "undefine" | "replace";
   redactWith?: "*" | "•" | "[redacted]" | string;
   percentage?: number;
   complementary?: boolean;


### PR DESCRIPTION
To make it clearer how to replace any value with a fixed string, I added the 'replace' mask type﻿ and improved types so only the allowed fields are exposed when using the Typescript API.

Also `type: "percentage"` now defaults to 100% `•`
