### PR TITLE
chore: Export all TS types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { redactIt } from "./src/redact-it";
+export * from "./typings";

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -4,15 +4,17 @@ import {
   RedactItConfig,
   ReplacerFunction,
   PercentageMask,
+  CenterPercentageMask,
 } from "../typings";
 
 const percentageValueMasker = (
   value: any,
-  mask: PercentageMask
+  mask: PercentageMask | CenterPercentageMask
 ): string | undefined => {
   const redactor = mask.redactWith ?? "•";
   const percentage = mask.percentage ?? 100;
-  const complementary = mask.complementary ?? false;
+  const complementary =
+    (mask.position === "center" && mask.complementary) ?? false;
   const position = mask.position ?? "left";
 
   const finalRedactor = (p1: string): string =>
@@ -29,6 +31,9 @@ const percentageValueMasker = (
     if (position === "center") {
       return `(.{${unmaskedLength / 2}})(.{${maskedLength}})(.+)`;
     }
+    if (position === "right") {
+      return `(.{${unmaskedLength}})(.{${maskedLength}})`;
+    }
     return `(.{${maskedLength}})(.{${unmaskedLength}})`;
   };
 
@@ -36,14 +41,18 @@ const percentageValueMasker = (
 
   const masoq = (_match: any, p1: string, p2: string, p3?: string): string => {
     if (p3 && complementary) {
+      // Center + complementary
       return `${finalRedactor(p1)}${p2}${finalRedactor(p3)}`;
     }
     if (p3) {
+      // Center
       return `${p1}${finalRedactor(p2)}${p3}`;
     }
-    if (complementary || (position === "right" && !complementary)) {
+    if (position === "right") {
+      // Right
       return `${p1}${finalRedactor(p2)}`;
     }
+    // Left
     return `${finalRedactor(p1)}${p2}`;
   };
 

--- a/src/redact-it.ts
+++ b/src/redact-it.ts
@@ -1,7 +1,7 @@
 import {
   Mask,
   RedactIt,
-  RedacItConfig,
+  RedactItConfig,
   ReplacerFunction,
   PercentageMask,
 } from "../typings";
@@ -53,25 +53,25 @@ const percentageValueMasker = (
 };
 
 export const redactIt: RedactIt = (
-  configs?: RedacItConfig | RedacItConfig[]
+  configs?: RedactItConfig | RedactItConfig[]
 ): ReplacerFunction => {
   const defaultMask: Mask = {
     type: "replace",
     redactWith: "[redacted]",
   };
 
-  const defaultOptions: RedacItConfig = {
+  const defaultOptions: RedactItConfig = {
     fields: ["password"],
     mask: defaultMask,
   };
 
   const mappedFields: Map<string | RegExp, Mask> = new Map();
 
-  const optionsArray: RedacItConfig[] = Array.isArray(configs)
+  const optionsArray: RedactItConfig[] = Array.isArray(configs)
     ? configs
     : [configs ?? defaultOptions];
 
-  optionsArray.forEach((option: RedacItConfig) => {
+  optionsArray.forEach((option: RedactItConfig) => {
     option.fields.forEach((field) => {
       mappedFields.set(field, option.mask ?? defaultMask);
     });

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -300,4 +300,30 @@ describe("Redact-it - Multiple configs argument", () => {
       authorization: "•••••case",
     });
   });
+
+  it("overrides configs for same field", () => {
+    const myData = { ...defaultObject };
+    const replacerFunction = redactIt([
+      {
+        fields: ["email", "name"],
+        mask: {
+          type: "replace",
+          redactWith: "firstRule",
+        },
+      },
+      {
+        fields: ["email"],
+        mask: {
+          type: "replace",
+          redactWith: "secondRule",
+        },
+      },
+    ]);
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+    const parsedResult = JSON.parse(stringResult);
+
+    expect(parsedResult.name).to.be.equal("firstRule");
+    expect(parsedResult.email).to.be.equal("secondRule");
+  });
 });

--- a/test/unit/redact-it.test.ts
+++ b/test/unit/redact-it.test.ts
@@ -129,23 +129,6 @@ describe("Redact-it - Single configs argument", () => {
     expect(JSON.parse(stringResult).card.number).to.be.eq("************4321");
   });
 
-  it("should redact the last 4 digits of a 16 digits value when a 75% complementary percentage mask is used", async () => {
-    const myData = { ...defaultObject };
-    const replacerFunction: ReplacerFunction = redactIt({
-      fields: ["number"],
-      mask: {
-        type: "percentage",
-        redactWith: "*",
-        percentage: 75,
-        complementary: true,
-      },
-    });
-
-    const stringResult = JSON.stringify(myData, replacerFunction);
-
-    expect(JSON.parse(stringResult).card.number).to.be.eq("123456788765****");
-  });
-
   it("should redact the middle digits when position center is used", async () => {
     const myData = { ...defaultObject };
     const replacerFunction: ReplacerFunction = redactIt({
@@ -162,6 +145,25 @@ describe("Redact-it - Single configs argument", () => {
 
     expect(JSON.parse(stringResult).email).to.be.eq(
       "foo123*************ar.com"
+    );
+  });
+
+  it("should redact the last digits when position right is used", async () => {
+    const myData = { ...defaultObject };
+    const replacerFunction: ReplacerFunction = redactIt({
+      fields: ["email"],
+      mask: {
+        type: "percentage",
+        redactWith: "*",
+        percentage: 75,
+        position: "right",
+      },
+    });
+
+    const stringResult = JSON.stringify(myData, replacerFunction);
+
+    expect(JSON.parse(stringResult).email).to.be.eq(
+      "foo123*******************"
     );
   });
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,6 +1,31 @@
-export type Mask = PercentageMask | UndefineMask | ReplaceMask;
+export type Mask =
+  | PercentageMask
+  | CenterPercentageMask
+  | UndefineMask
+  | ReplaceMask;
+
 export interface PercentageMask {
   type: "percentage";
+  /**
+   * Character to be used as the redacted part
+   * @default "•"
+   */
+  redactWith?: "*" | "•" | string;
+  /**
+   * Percentage of the value to apply the mask on
+   * @default 100
+   */
+  percentage?: number;
+  /**
+   * Which part of the value to redact
+   * @default "left"
+   */
+  position?: "left" | "right";
+}
+
+export interface CenterPercentageMask {
+  type: "percentage";
+  position: "center";
   /**
    * Character to be used as the redacted part
    * @default "•"
@@ -16,12 +41,8 @@ export interface PercentageMask {
    * @default false
    */
   complementary?: boolean;
-  /**
-   * Which part of the value to redact
-   * @default "left"
-   */
-  position?: "left" | "center" | "right";
 }
+
 export interface UndefineMask {
   type: "undefine";
 }
@@ -34,7 +55,7 @@ export interface ReplaceMask {
   redactWith: "[redacted]" | string;
 }
 
-export interface RedactConfig {
+export interface RedactItConfig {
   /** Field names to redact */
   fields: (string | RegExp)[];
   /** Which mask to apply */

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -27,7 +27,7 @@ export interface ReplaceMask {
  *  @param {string[]} fields - Field names to redact
  *  @param {Mask} mask - Which mask to apply
  */
-export interface RedacItConfig {
+export interface RedactItConfig {
   fields: (string | RegExp)[];
   mask?: Mask;
 }
@@ -37,9 +37,9 @@ export type ReplacerFunction = (key: any, value: any) => any;
 /**
  *  A function that takes the argument and creates a replacer function
  *  The arguement may be a single object of the RedacItConfig type or an array of these objects
- *  @param {RedacItConfig | RedacItConfig[]} configs - RedacItConfig to customize the redact function
+ *  @param {RedactItConfig | RedactItConfig[]} configs - RedacItConfig to customize the redact function
  *  @param {function} replacer - A replacer function compatible with JSON.stringify
  */
 export type RedactIt = (
-  configs?: RedacItConfig | RedacItConfig[]
+  configs?: RedactItConfig | RedactItConfig[]
 ) => ReplacerFunction;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,17 +1,25 @@
-/**
- *  Mask options
- *  @param {string} type - Type of the mask to be applied
- *  @param {string} redactWith - Character or word to be used as the redacted part
- *  @param {number} percentage - Percentage of the value to apply the mask on
- *  @param {boolean} complementary - Whether the complemetary part of the percentage should be masked
- */
 export type Mask = PercentageMask | UndefineMask | ReplaceMask;
-
 export interface PercentageMask {
   type: "percentage";
-  redactWith?: "*" | "•" | "[redacted]" | string;
+  /**
+   * Character to be used as the redacted part
+   * @default "•"
+   */
+  redactWith?: "*" | "•" | string;
+  /**
+   * Percentage of the value to apply the mask on
+   * @default 100
+   */
   percentage?: number;
+  /**
+   * Whether the complementary part of the percentage should be masked
+   * @default false
+   */
   complementary?: boolean;
+  /**
+   * Which part of the value to redact
+   * @default "left"
+   */
   position?: "left" | "center" | "right";
 }
 export interface UndefineMask {
@@ -19,26 +27,28 @@ export interface UndefineMask {
 }
 export interface ReplaceMask {
   type: "replace";
+  /**
+   * Replace the value entirely with this string
+   * @default "[redacted]"
+   */
   redactWith: "[redacted]" | string;
 }
 
-/**
- *  Redact-it configs to customize how and which fields are going to be redacted
- *  @param {string[]} fields - Field names to redact
- *  @param {Mask} mask - Which mask to apply
- */
-export interface RedactItConfig {
+export interface RedactConfig {
+  /** Field names to redact */
   fields: (string | RegExp)[];
+  /** Which mask to apply */
   mask?: Mask;
 }
 
+/** A replacer function compatible with JSON.stringify */
 export type ReplacerFunction = (key: any, value: any) => any;
 
 /**
  *  A function that takes the argument and creates a replacer function
- *  The arguement may be a single object of the RedacItConfig type or an array of these objects
- *  @param {RedactItConfig | RedactItConfig[]} configs - RedacItConfig to customize the redact function
- *  @param {function} replacer - A replacer function compatible with JSON.stringify
+ *  The argument may be a single object of the RedactItConfig type or an array of these objects
+ *  @param {RedactItConfig | RedactItConfig[]} configs - RedactItConfig to customize the redact function
+ *  @return {ReplacerFunction} replacer - A replacer function compatible with JSON.stringify
  */
 export type RedactIt = (
   configs?: RedactItConfig | RedactItConfig[]

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -55,6 +55,7 @@ export interface ReplaceMask {
   redactWith: "[redacted]" | string;
 }
 
+/** Redact-it configs to customize how and which fields are going to be redacted */
 export interface RedactItConfig {
   /** Field names to redact */
   fields: (string | RegExp)[];


### PR DESCRIPTION
- Export all types from `/typings/index.ts` file
    This allows consumers to declare configs in their own code without needing to use `import { RedactItConfig } from "redact-it/dist/typings"`
    
- Remove `complementary` for non-`center` positions, as it is undocumented and confusing
- Improve JSDocs on types

    
- Rename `RedacItConfig` to `RedactItConfig` (typo)
- Add test to ensure rules can be overriden
